### PR TITLE
fix: update FluidCursor component to disable pointer events for the fluid effect

### DIFF
--- a/registry/components/cursor/common/fluid-cursor.tsx
+++ b/registry/components/cursor/common/fluid-cursor.tsx
@@ -9,7 +9,7 @@ const FluidCursor = () => {
   }, []);
 
   return (
-    <div className='fixed top-0 left-0 z-2'>
+    <div className='fixed top-0 left-0 z-2 pointer-events-none'>
       <canvas id='fluid' className='w-screen h-screen' />
     </div>
   );


### PR DESCRIPTION
**Description**
Hey guys, im unable to click/interract with clickable elements afters switching on fluid cursor. Decided to debug it and propose my fix.

**Steps to Reproduce**
Switch on fluid effect cursor on your website and try then to switch on another cursor, its unable to change then. Look on screenshots section - i put video there.

**Screenshots**
Here’s an example of this bug
[screen-capture.webm](https://github.com/user-attachments/assets/0a03e12a-e25c-4fe2-af20-319dee4b7689)

**Environment**

Browser: Chrome/Firefox
OS: Linux Mint 21.3
Device: Desktop