### PR TITLE
Update use-mouse.ts

### DIFF
--- a/hooks/use-mouse.ts
+++ b/hooks/use-mouse.ts
@@ -20,7 +20,7 @@ export function useMouse(): [MouseState, RefObject<HTMLDivElement>] {
     elementPositionY: null,
   });
 
-  const ref = useRef<HTMLDivElement | null>(null);
+  const ref = useRef<HTMLDivElement>(null as unknown as HTMLDivElement);
 
   useLayoutEffect(() => {
     const handleMouseMove = (event: MouseEvent) => {


### PR DESCRIPTION
 Changed useRef<HTMLDivElement | null>(null) ➝ Now using null as unknown as HTMLDivElement.
 Ensuring TypeScript doesn't complain about null assignment to ref.current as it was causing error.